### PR TITLE
:herb: bump node generator

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -19,7 +19,7 @@ groups:
   ts-sdk: 
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.12.5
+        version: 0.12.7
         # output:
         #   location: npm
         #   package-name: "@octoai/octoai-node-client"

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "octoai",
-  "version": "0.19.4"
+  "version": "0.19.9"
 }


### PR DESCRIPTION
This version includes:
- Environment variable defaults for the node generator
- A fix to the default node-fetch usage


Changelog: https://github.com/fern-api/fern/blob/main/generators/typescript/sdk/CHANGELOG.md#0127---2024-03-14