### PR TITLE
Downgrade python code gen to 1.5.0-rc0 for now

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -2,7 +2,7 @@ groups:
   python-sdk-local:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 1.5.1-rc1
+        version: 1.5.0-rc0
         config:
           inline_request_params: true
           client:
@@ -20,7 +20,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 1.5.1-rc1
+        version: 1.5.0-rc0
         output:
           location: pypi
           package-name: "octoai"


### PR DESCRIPTION
Fern is working on a fix but this should fix the python sdk for now.