### PR TITLE
Fix json-mode.mdx

### DIFF
--- a/fern/docs/text-gen-solution/json-mode.mdx
+++ b/fern/docs/text-gen-solution/json-mode.mdx
@@ -265,7 +265,7 @@ class UserExtract(BaseModel):
     age: int
 
 
-user: UserExtract = octoai.text_gen.create_completion(
+user: UserExtract = client.chat.completions.create(
     model="mistral-7b-instruct",
     response_model=UserExtract,
     messages=[


### PR DESCRIPTION
the `instructor` python package example provided only works with openai sdk. Therefore, the client method used for creating a completion should be based on openai sdk.