### PR TITLE
fix: move mock libraries to dev deps

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -53,6 +53,7 @@ groups:
           includeApiReference: true
           extraDependencies:
             '@aws-sdk/client-s3': '^3.540.0'
+          extraDevDependencies:
             'aws-sdk-client-mock': '^4.0.0'
             'aws-sdk-client-mock-jest': '^4.0.0'
         smart-casing: true
@@ -73,6 +74,7 @@ groups:
           includeApiReference: true
           extraDependencies:
             '@aws-sdk/client-s3': '^3.540.0'
+          extraDevDependencies:
             'aws-sdk-client-mock': '^4.0.0'
             'aws-sdk-client-mock-jest': '^4.0.0'
         smart-casing: true


### PR DESCRIPTION
Should decrease the install size by quite a bit since mock/test libraries can get chonky