### PR TITLE
(fix): upgrade fern to `0.31.3`

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "octoai",
-  "version": "0.31.2"
+  "version": "0.31.3"
 }


### PR DESCRIPTION
This PR fixes parsing of `exclusiveMaximum` and `exclusiveMinimum` fields.