### PR TITLE
(chore): enable auth in playground

### DIFF
--- a/fern/apis/api/definition/api.yml
+++ b/fern/apis/api/definition/api.yml
@@ -4,9 +4,9 @@ display-name: OctoAI
 error-discrimination:
   strategy: status-code
 
-auth: BearerAuthScheme
+auth: BearerAuth
 auth-schemes: 
-  BearerAuthScheme: 
+  BearerAuth: 
     scheme: bearer
     token: 
       name: api_key

--- a/fern/apis/asset-library/openapi/openapi-overrides.yml
+++ b/fern/apis/asset-library/openapi/openapi-overrides.yml
@@ -40,3 +40,5 @@ components:
       x-fern-bearer:
         name: apiKey
         env: OCTOAI_API_KEY
+security:
+  - BearerAuth: []

--- a/fern/apis/fine-tuning/openapi/openapi-overrides.yml
+++ b/fern/apis/fine-tuning/openapi/openapi-overrides.yml
@@ -50,3 +50,5 @@ components:
       x-fern-bearer:
         name: apiKey
         env: OCTOAI_API_KEY
+security:
+  - BearerAuth: []

--- a/fern/apis/image-gen-util/openapi/openapi-overrides.yml
+++ b/fern/apis/image-gen-util/openapi/openapi-overrides.yml
@@ -54,4 +54,6 @@ components:
       x-fern-type-name: UpscalingRequest
     ValidationError:
       x-fern-type-name: ValidationError
+security:
+  - BearerAuth: []
       

--- a/fern/apis/image-gen/openapi/openapi-overrides.yml
+++ b/fern/apis/image-gen/openapi/openapi-overrides.yml
@@ -74,3 +74,5 @@ components:
       x-fern-bearer:
         name: apiKey
         env: OCTOAI_API_KEY
+security:
+  - BearerAuth: []

--- a/fern/apis/text-gen/openapi/openapi-overrides.yml
+++ b/fern/apis/text-gen/openapi/openapi-overrides.yml
@@ -33,3 +33,5 @@ components:
       x-fern-bearer:
         name: apiKey
         env: OCTOAI_API_KEY
+security:
+  - BearerAuth: []


### PR DESCRIPTION
This PR adds configuration to the `overrides` to enable authentication within the API playground