### PR TITLE
feat: remove IP Adapter

### DIFF
--- a/fern/apis/image-gen/openapi/openapi-overrides.yml
+++ b/fern/apis/image-gen/openapi/openapi-overrides.yml
@@ -30,6 +30,9 @@ paths:
       servers:
         - url: https://image.octoai.run
           x-name: ImageGen
+  /generate/ip-adapter-sdxl:
+    post:
+      x-fern-ignore: true
   /generate/flux-schnell:
     post:
       summary: "Generate FLUX.1 [schnell]"

--- a/fern/apis/image-gen/openapi/openapi-overrides.yml
+++ b/fern/apis/image-gen/openapi/openapi-overrides.yml
@@ -30,13 +30,6 @@ paths:
       servers:
         - url: https://image.octoai.run
           x-name: ImageGen
-  /generate/ip-adapter-sdxl:
-    post:
-      summary: "IP Adapter"
-      x-fern-sdk-method-name: ip_adapter
-      servers:
-        - url: https://image.octoai.run
-          x-name: ImageGen
   /generate/flux-schnell:
     post:
       summary: "Generate FLUX.1 [schnell]"

--- a/fern/apis/image-gen/openapi/openapi-overrides.yml
+++ b/fern/apis/image-gen/openapi/openapi-overrides.yml
@@ -30,9 +30,6 @@ paths:
       servers:
         - url: https://image.octoai.run
           x-name: ImageGen
-  /generate/ip-adapter-sdxl:
-    post:
-      x-fern-ignore: true
   /generate/flux-schnell:
     post:
       summary: "Generate FLUX.1 [schnell]"


### PR DESCRIPTION
The updated OpenAPI spec for image gen doesn't have IP Adapter anymore since the spec for that feature is from a pending PR. The current SDK has an `ipAdapter` method but has no arguments and returns a `Promise<void>`.